### PR TITLE
Foursquares Checkins

### DIFF
--- a/Main.php
+++ b/Main.php
@@ -139,7 +139,6 @@
                 function getVenues($ll) {
 		    $response = false;
                     if ($this->hasFoursquare()) {
-			     \Idno\Core\Idno::site()->logging->debug('VEN ll'.$ll);
                                 $fsObj = $this->connect();
                             /* @var \EpiFoursquare $fsObj */
                             if ($venues = $fsObj->get('/venues/search', array('ll' => $ll, 'v' => '20131031'))) {

--- a/Main.php
+++ b/Main.php
@@ -19,12 +19,15 @@
                 \Idno\Core\site()->addPageHandler('admin/foursquare', '\IdnoPlugins\Foursquare\Pages\Admin');
                 // Register settings page
                 \Idno\Core\site()->addPageHandler('account/foursquare', '\IdnoPlugins\Foursquare\Pages\Account');
+                // Register venue page
+                \Idno\Core\site()->addPageHandler('foursquare/venues', '\IdnoPlugins\Foursquare\Pages\Venues');
 
                 /** Template extensions */
                 // Add menu items to account & administration screens
                 \Idno\Core\site()->template()->extendTemplate('admin/menu/items', 'admin/foursquare/menu');
                 \Idno\Core\site()->template()->extendTemplate('account/menu/items', 'account/foursquare/menu');
                 \Idno\Core\site()->template()->extendTemplate('onboarding/connect/networks', 'onboarding/connect/foursquare');
+                \Idno\Core\site()->template()->extendTemplate('shell/footer', 'entry/footer');
             }
 
             function registerEventHooks()
@@ -133,6 +136,20 @@
 
             }
 
+                function getVenues($ll) {
+		    $response = false;
+                    if ($this->hasFoursquare()) {
+			     \Idno\Core\Idno::site()->logging->debug('VEN ll'.$ll);
+                                $fsObj = $this->connect();
+                            /* @var \EpiFoursquare $fsObj */
+                            if ($venues = $fsObj->get('/venues/search', array('ll' => $ll, 'v' => '20131031'))) {
+                                if (!empty($venues->response->venues) && is_array($venues->response->venues)) {
+                                        $response  = $venues->response->venues;
+				    }
+                                } 
+                            }
+		    return $response;
+            }
             /**
              * Connect to Foursquare
              * @return bool|\Foursquare

--- a/Pages/Venues.php
+++ b/Pages/Venues.php
@@ -1,0 +1,39 @@
+<?php
+
+    /**
+     * Plugin administration
+     */
+
+    namespace IdnoPlugins\Foursquare\Pages {
+
+        class Venues extends \Idno\Common\Page
+        {
+		function getContent()
+		{
+			$this->gatekeeper();
+			$foursquare = \Idno\Core\site()->plugins()->get('Foursquare');
+			$response = array();
+			$ll = $this->getInput('ll');
+			if (!empty($ll)) {
+				if ($venues = $foursquare->getVenues($ll)) {
+					\Idno\Core\Idno::site()->logging->debug('VENUES '.print_r($venues,true));
+
+					foreach ($venues as $venue) {
+						$response[] = array(
+							'id' => $venue->id,
+							'name' => $venue->name,
+							'lat' => $venue->location->lat,
+							'long' => $venue->location->lng,
+							'address' => implode(" ",$venue->location->formattedAddress),
+							'icon32'    => $venue->categories[0]->icon->prefix . "bg_32". $venue->categories[0]->icon->suffix
+						);
+							
+					}
+				}
+			}
+			header('Content-type: text/json');
+			echo json_encode($response, JSON_PRETTY_PRINT);
+		}
+        }
+
+    }

--- a/Pages/Venues.php
+++ b/Pages/Venues.php
@@ -15,17 +15,16 @@
 			$response = array();
 			$ll = $this->getInput('ll');
 			if (!empty($ll)) {
+				$icon = (!empty($venue->categories) ? $venue->categories[0]->icon->prefix . "bg_32". $venue->categories[0]->icon->suffix : "https://foursquare.com/img/categories_v2/none_bg_32.png");
 				if ($venues = $foursquare->getVenues($ll)) {
-					\Idno\Core\Idno::site()->logging->debug('VENUES '.print_r($venues,true));
-
 					foreach ($venues as $venue) {
 						$response[] = array(
-							'id' => $venue->id,
-							'name' => $venue->name,
-							'lat' => $venue->location->lat,
-							'long' => $venue->location->lng,
+							'id'      => $venue->id,
+							'name'    => $venue->name,
+							'lat'     => $venue->location->lat,
+							'long'    => $venue->location->lng,
 							'address' => implode(" ",$venue->location->formattedAddress),
-							'icon32'    => $venue->categories[0]->icon->prefix . "bg_32". $venue->categories[0]->icon->suffix
+							'icon32'  => $icon
 						);
 							
 					}

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -1,10 +1,9 @@
 
 var venues = [];
-var map = null;
 
 $(function () {
     
-    $('input[name="syndication[]"]').change(function () {
+   $(document).on('change', 'input[name="syndication[]"]',function(){
         var latitude = $('#lat').val(), longitude = $('#long').val();
         if ($('input[name="syndication[]"]').prop("checked")) {
             if (longitude && longitude) {
@@ -17,7 +16,6 @@ $(function () {
                 dropdown += '    <span class="caret"></span></a>';
                 dropdown += '    <ul class="dropdown-menu">';
                 $('input[type="submit"]').prop('disabled', true);
-                console.log("fsq " + fsq + "?ll=" + ltlg);
                 $.getJSON(fsq, {ll: ltlg})
                         .done(function (data) {
                             $.each(data, function (key, val) {
@@ -60,7 +58,6 @@ $(document).ready(function () {
 
 
 $(document).on('click', 'a.venue-name', function () {
-    console.log("VENUE CLICKED");
     venueControlId = $(this).data('key');
     $('#venue-button').html($(this).html() + ' <span class="caret"></span>');
     $('#venue-button').click();
@@ -69,8 +66,6 @@ $(document).on('click', 'a.venue-name', function () {
     var venue_name = venues[venue_key].name;
     var lat = venues[venue_key].lat;
     var lng = venues[venue_key].long;
-    console.log("venue name: " + venue_name);
-    console.log("venue addresse: " + venue_address);
     $('#user_address').val(venue_address);
     $('#placename').val(venue_name);
     $('#venuename').val(venue_name);
@@ -95,7 +90,6 @@ function queryLocation(latitude, longitude) {
         type: 'post',
         data: {lat: latitude.toString(), long: longitude.toString()}
     }).done(function (data) {
-        console.log(data);
         $('#lat').val(latitude);
         $('#long').val(longitude);
         $('#address').val(data.display_name);

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -89,7 +89,7 @@ function queryLocation(latitude, longitude) {
 }
 
 // get new venues after moving marker
-$(document).on('mouseup mousedown', '.leaflet-marker-icon', function () {
+$(document).on('mouseup mousedown touchstart touchend', '.leaflet-marker-icon', function () {
     var ll = CheckinMarker.getLatLng();
     CheckinMap.setView(ll, 15);
     var latitude = $('#lat').val(), longitude = $('#long').val();
@@ -110,6 +110,3 @@ $(document).on('mouseup mousedown', '.leaflet-marker-icon', function () {
     }
 
 });
-
-
-

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -1,0 +1,107 @@
+
+var venues = [];
+var map = null;
+
+$(function () {
+    
+    $('input[name="syndication[]"]').change(function () {
+        var latitude = $('#lat').val(), longitude = $('#long').val();
+        if ($('input[name="syndication[]"]').prop("checked")) {
+            if (longitude && longitude) {
+                var ltlg = latitude + "," + longitude;
+                var fsq = wwwroot() + "foursquare/venues";
+                var options = "";
+                var dropdown = '<div class="dropdown">';
+                dropdown += '    <a id="venue-button" href="#" class="btn btn-info text-left col-xs-12 dropdown-toggle" type="button" data-toggle="dropdown">';
+                dropdown += '        Select 4sq Venue';
+                dropdown += '    <span class="caret"></span></a>';
+                dropdown += '    <ul class="dropdown-menu">';
+                $('input[type="submit"]').prop('disabled', true);
+                console.log("fsq " + fsq + "?ll=" + ltlg);
+                $.getJSON(fsq, {ll: ltlg})
+                        .done(function (data) {
+                            $.each(data, function (key, val) {
+                                options += '<li> <a href="#" class="venue-name"  data-key = "' + key + '">' + '<img src="' + val.icon32 + '" width="18" height="18"> ' + val.name + '</a></li>';
+                            });
+                            venues = data;
+                            dropdown += options;
+                            dropdown += '    </ul>';
+                            dropdown += '</div>';
+                            $('label[for=placename]').before(dropdown);
+                            $('label[for=placename]').attr("for", "venuename");
+                            $('#placename').before('<input name="venuename" id="venuename" class="form-control"  value="" type="text" readonly="readonly">');
+                            $('#placename').replaceWith('<input name="placename" id="placename"  value="" type="hidden">');
+                            $('#user_address').attr("readonly","readonly");
+                        });
+            }
+        }
+    });
+});
+
+
+$('.DDvenue-name').on('click', function (p) {
+    p.preventDefault();
+    var venue_key = $(this).data('key');
+    var venue_address = venue[venue_key].address;
+    var venue_name = venue[venue_key].name;
+    $('user_address').val(venue_address);
+    $('#placename').val(venue_name);
+    $('#venuename').val(venue_name);
+    $('input[type="submit"]').prop('disabled', false);
+});
+
+$(document).ready(function () {
+    $('.venue-name').each(function () {
+        if ($(this).data('key') == venue - control - id) {
+            $('#venue-button').html($(this).html() + ' <span class="caret"></span>');
+        }
+    })
+});
+
+
+$(document).on('click', 'a.venue-name', function () {
+    console.log("VENUE CLICKED");
+    venueControlId = $(this).data('key');
+    $('#venue-button').html($(this).html() + ' <span class="caret"></span>');
+    $('#venue-button').click();
+    var venue_key = $(this).data('key');
+    var venue_address = venues[venue_key].address;
+    var venue_name = venues[venue_key].name;
+    var lat = venues[venue_key].lat;
+    var lng = venues[venue_key].long;
+    console.log("venue name: " + venue_name);
+    console.log("venue addresse: " + venue_address);
+    $('#user_address').val(venue_address);
+    $('#placename').val(venue_name);
+    $('#venuename').val(venue_name);
+    $('#lat').val(venues[venue_key].lat);
+    $('#long').val(venues[venue_key].long);
+    $('input[type="submit"]').prop('disabled', false);
+    queryLocation(lat, lng);
+    var newLatLng = new L.LatLng(lat, lng);
+    CheckinMarker.setLatLng(newLatLng).update();
+    CheckinMap.panTo(newLatLng);
+});
+
+$('#access-control-id').on('change', function () {
+
+});
+var venueControlId = 0;
+
+
+function queryLocation(latitude, longitude) {
+    $.ajax({
+        url: '/checkin/callback',
+        type: 'post',
+        data: {lat: latitude.toString(), long: longitude.toString()}
+    }).done(function (data) {
+        console.log(data);
+        $('#lat').val(latitude);
+        $('#long').val(longitude);
+        $('#address').val(data.display_name);
+        $('#user_address').val(data.display_name);
+    });
+}
+
+
+

--- a/js/javascript.js
+++ b/js/javascript.js
@@ -1,5 +1,6 @@
-
+var venueControlId = 0;
 var venues = [];
+var fsqEnabled = false;
 
 $(function () {
     
@@ -37,29 +38,24 @@ $(function () {
 });
 
 
-$('.DDvenue-name').on('click', function (p) {
-    p.preventDefault();
-    var venue_key = $(this).data('key');
-    var venue_address = venue[venue_key].address;
-    var venue_name = venue[venue_key].name;
-    $('user_address').val(venue_address);
-    $('#placename').val(venue_name);
-    $('#venuename').val(venue_name);
-    $('input[type="submit"]').prop('disabled', false);
-});
 
 $(document).ready(function () {
     $('.venue-name').each(function () {
-        if ($(this).data('key') == venue - control - id) {
-            $('#venue-button').html($(this).html() + ' <span class="caret"></span>');
+        if ($(this).data('key') == venueControlId) {
+		var html = $(this).html();
+		html.replace('_bg','');
+            $('#venue-button').html($(this).html().replace('_bg','') + ' <span class="caret"></span>');
         }
-    })
+    });
 });
 
 
 $(document).on('click', 'a.venue-name', function () {
     venueControlId = $(this).data('key');
+    src = $(this).children('img').attr('src');
+    src = src.replace('_bg','');
     $('#venue-button').html($(this).html() + ' <span class="caret"></span>');
+    $('#venue-button').children('img').attr('src',src);
     $('#venue-button').click();
     var venue_key = $(this).data('key');
     var venue_address = venues[venue_key].address;
@@ -78,12 +74,7 @@ $(document).on('click', 'a.venue-name', function () {
     CheckinMap.panTo(newLatLng);
 });
 
-$('#access-control-id').on('change', function () {
-
-});
-var venueControlId = 0;
-
-
+//get address from location
 function queryLocation(latitude, longitude) {
     $.ajax({
         url: '/checkin/callback',
@@ -96,6 +87,29 @@ function queryLocation(latitude, longitude) {
         $('#user_address').val(data.display_name);
     });
 }
+
+// get new venues after moving marker
+$(document).on('mouseup mousedown', '.leaflet-marker-icon', function () {
+    var ll = CheckinMarker.getLatLng();
+    CheckinMap.setView(ll, 15);
+    var latitude = $('#lat').val(), longitude = $('#long').val();
+    if (fsqEnabled && latitude && longitude) {
+        var ltlg = latitude + "," + longitude;
+        var fsq = wwwroot() + "foursquare/venues";
+        var options = "";
+        $.getJSON(fsq, {ll: ltlg})
+                .done(function (data) {
+                    $.each(data, function (key, val) {
+                        options += '<li> <a href="#" class="venue-name"  data-key = "' + key + '">' + '<img src="' + val.icon32 + '" width="18" height="18"> ' + val.name + '</a></li>';
+                    });
+                    venues = data;
+                    $('ul.dropdown-menu').html(options);
+                    $('input[type="submit"]').prop('disabled', true);
+                    $('#venue-button').html('        <i class="fa fa-foursquare"></i>Select Foursquare Venue');
+                });
+    }
+
+});
 
 
 

--- a/templates/default/entry/footer.tpl.php
+++ b/templates/default/entry/footer.tpl.php
@@ -1,0 +1,3 @@
+<script type="text/javascript" src="<?php echo \Idno\Core\site()->config()->getDisplayURL() ?>IdnoPlugins/Foursquare/js/javascript.js"></script>
+
+


### PR DESCRIPTION
When syndicating to 4sq, the place doesn't correspond to the actual location (see [#1290](https://github.com/idno/Known/issues/1290)). 
This PR will address it as it will limit the places to the places known by Foursquare.
- location field is hidden when 4sq syndication is enabled
- when re-positioning marker, list of places is repopulated
- publish button disabled as long no place is selected 
## Preview

![screenshot_2016-02-25-17-34-46](https://cloud.githubusercontent.com/assets/54977/13327002/66e0e20c-dbe8-11e5-8c34-c58f25a568af.png)
# enabling 4sq:

![screenshot_2016-02-25-17-35-13](https://cloud.githubusercontent.com/assets/54977/13327045/8d3d33b0-dbe8-11e5-9d54-1b4e0bf01abe.png)

![screenshot_2016-02-25-17-35-16](https://cloud.githubusercontent.com/assets/54977/13327019/70b57e6e-dbe8-11e5-9fd2-23e1b1b0005f.png)
# Pan & zoom to new place

![screenshot_2016-02-25-17-35-43](https://cloud.githubusercontent.com/assets/54977/13327083/bb3674ac-dbe8-11e5-8b60-7e41b20557cf.png)
